### PR TITLE
338 downcasing the recording_method text only not the whole sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1 / 2018-07-26
+
+* [BUG] - [Print stylesheet styles links as clickable](https://github.com/barnardos/consent-form-builder/issues/338)
+
 # 2.0.0 / 2018-07-10
 
 * [BUG] - [Remove the version number](https://github.com/barnardos/consent-form-builder/issues/311)

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -334,14 +334,14 @@
                     else
                       c(
                         'Output',
-                        text:  t("#{ct}.the_research.recording_methods.#{recording_method}"),
+                        text:  t("#{ct}.the_research.recording_methods.#{recording_method}").downcase,
                         field: 'recording_methods',
                         url: edit_link_for(:recording_methods)
                       )
                     end
                   }
             %>
-            <%= raw t("#{ct}.giving_your_consent.activities", recording_methods: recording_methods.to_sentence.downcase) %>
+            <%= raw t("#{ct}.giving_your_consent.activities", recording_methods: recording_methods.to_sentence) %>
           <% end %>
           <%= c('ListItem') do %>
             <%= t("#{ct}.giving_your_consent.data") %>


### PR DESCRIPTION
Downcasing the whole sentence was affecting the class names in the Output component as well so I've downcased the recording_method text only instead of the whole thing. 

If I understand correctly, when the recording_method === 'other' it means it's added by user so downcasing the text there might not be the best idea so I have left it as it is.